### PR TITLE
Add datetime representation.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -596,18 +596,18 @@ consectetur adipiscing elit.'
   <h1>Dates and Times</h1>
 
   <p>
+    JSON5, like ECMAScript, defines a string interchange format for date-times 
+    based upon a simplification of the ISO 8601 Extended Format.
     A JSON5 string can be declared to encode a date, time or datetime, using
     the `jsondate:` prefix. Any string that is prefixed with `jsondate:` MUST 
-    conform to the `date-time` production of 
-    <a href="https://tools.ietf.org/html/rfc3339#section-5.6">RFC 3339</a>
-    and represents a moment in Coordinated Universal Time (UTC). 
-    Datetimes MUST use T as the separator character.
+    conform to the syntax and semantics of the `Date Time String Format` format of 
+    <a href="https://es5.github.io/x15.9.html#x15.9.1.15">ECMAScript 5</a>.
   </p>
 
   <emu-example>
     <pre><code class="javascript">
 {
-    billenium: 'jsondatetime:2001-09-09T01:46:40.000001Z',
+    billenium: 'jsondatetime:2001-09-09T01:46:40.0001Z',
 }
 </code></pre>
   </emu-example>

--- a/src/index.html
+++ b/src/index.html
@@ -592,6 +592,35 @@ consectetur adipiscing elit.'
   </emu-table>
 </emu-clause>
 
+<emu-clause id="dates-and-times">
+  <h1>Dates and Times</h1>
+
+  <p>
+    A JSON5 string can be declared to encode a date, time or datetime, using
+    the `jsondate:` prefix. Any string that is prefixed with `jsondate:` MUST 
+    conform to the `date-time` production of 
+    <a href="https://tools.ietf.org/html/rfc3339#section-5.6">RFC 3339</a>
+    and represents a moment in Coordinated Universal Time (UTC). 
+    Datetimes MUST use T as the separator character.
+  </p>
+
+  <emu-example>
+    <pre><code class="javascript">
+{
+    billenium: 'jsondatetime:2001-09-09T01:46:40.000001Z',
+}
+</code></pre>
+  </emu-example>
+
+  <p>
+    Some parsers may choose to have a mode where these dates are deserialized 
+    to language objects automatically. If the parser cannot represent all 
+    dates losslessly in native language objects, it should offer an option for 
+    returning the values as raw strings, custom objects or some other lossless format.
+  </p>
+
+</emu-clause>
+
 <emu-clause id="grammar">
   <h1>Grammar</h1>
 


### PR DESCRIPTION
This proposal tries to reflect the following design principles:

 * JSON5 is a specification, so it is more helpful when it is unambiguous and prescriptive rather than optional

 * JSON5 does not have any other "recommended" encodings that I noticed. Every element is unambiguously one type or another.

 * String prefixes are backwards compatible with regular JSON and with every existing JSON5 parser.

 * The biggest virtue of JSON is that parsers decode things to native objects with minimum intervention by the programmer.

 * Parsers generally do not have schemas available, and therefore must determine the types of things based on the actual syntax in the payload.

 * ECMAScript 5 has an unambiguous format for date strings, which is compatible with both IETF standards and ISO standards, and we should use it.
