### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ The latest version is available at https://spec.json5.org/
 To contribute to the spec, please install [Ecmarkup] and familiarize yourself
 with it.
 
-[Ecmarkup]: https://bterlson.github.io/ecmarkup/
+[Ecmarkup]: https://tc39.es/ecmarkup/


### PR DESCRIPTION
The current link to the `Ecmarkup` tool in the Readme is broken and points to a non-existing page. This pull request replaces it with the current link on the TC39's website.